### PR TITLE
Fallback to searching the store if snap not found locally

### DIFF
--- a/snappy/fake_snapd_client.go
+++ b/snappy/fake_snapd_client.go
@@ -24,7 +24,9 @@ import (
 // FakeSnapdClient is a fake SnapdClient for testing purposes
 type FakeSnapdClient struct {
 	Snaps           []*client.Snap
+	StoreSnaps      []*client.Snap
 	Err             error
+	StoreErr        error
 	CalledListSnaps bool
 	Query           string
 	Version         string
@@ -58,7 +60,7 @@ func (f *FakeSnapdClient) ListSnaps(names []string) ([]*client.Snap, error) {
 func (f *FakeSnapdClient) FindSnaps(query string) ([]*client.Snap, *client.ResultInfo, error) {
 	f.Query = query
 
-	return f.Snaps, nil, f.Err
+	return f.StoreSnaps, nil, f.StoreErr
 }
 
 // Install adds the named snap to the system


### PR DESCRIPTION
Recreation of [~stevenwilkin/webdm/get-snap-from-store/+merge/296774](https://code.launchpad.net/~stevenwilkin/webdm/get-snap-from-store/+merge/296774).

In the recent past a call to `/v2/snaps/<SNAP>` on the snapd API returned details of snaps available on the store if they weren't already installed locally. Now, this endpoint only returns details of snaps if they are already installed.

This change meant an error any time WebDM attempted to fetch the details of a not-yet-installed snap which includes installation and removal of snaps.

With this PR WebDM fallsback to a search of the store whenever retrieval of an individual snap fails.