### PR TITLE
Implement Vanilla buttons

### DIFF
--- a/www/src/css/installer.css
+++ b/www/src/css/installer.css
@@ -2,45 +2,23 @@
 
 .b-installer {
   position:relative;
-  font-size:12px;
-  width:100px;
 }
 
 .b-installer__button {
-  text-transform:uppercase;
-  background-color: #dd4814;
-  border-radius:4px;
-  color:#fff;
-  cursor:pointer;
-  font-weight:400;
-  overflow: hidden;
-  padding:8px 10px;
-  position:relative;
-  text-align:center;
-  text-overflow: ellipsis;
-  transition: background-color 0.3s;
-  user-select: none;
-  white-space: nowrap;
+  width:140px;
 }
 
-.b-installer_do_remove .b-installer__button {
-  background-color:#ccc;
-  color:#fff;
-  font-weight:300;
+.b-installer__button_large {
+  width:100%;
 }
 
 .b-installer_disabled .b-installer__button {
-  font-weight: inherit;
-  background-color: inherit;
-  color:#333;
+  background-color:#f7f7f7;
   cursor:not-allowed;
-  text-transform:none;
 }
 
 .b-installer_thinking .b-installer__button {
-  background-color:transparent;
   cursor:progress;
-  color:#dd4814;
 }
 
 .b-installer__message {

--- a/www/src/css/lib/vanilla-includes.scss
+++ b/www/src/css/lib/vanilla-includes.scss
@@ -10,6 +10,7 @@
 $brand_color: #fff;
 $breakpoint-medium: 640px;
 $navigation-threshold: 640px;
+$primary-button-color: #38b44a;
 
 // IMPORT VANILLA
 @import "../../../../node_modules/vanilla-framework/scss/vanilla";
@@ -25,6 +26,7 @@ $navigation-threshold: 640px;
 @include vf-lists;
 @include vf-typography;
 @include vf-grid;
+@include vf-buttons;
 
 // IMPORT VANILLA OVERRIDES
 @import "vanilla-overrides";

--- a/www/src/css/lib/vanilla-overrides.scss
+++ b/www/src/css/lib/vanilla-overrides.scss
@@ -57,3 +57,8 @@
     display:initial;
   }
 }
+
+// scss/modules/_buttons.scss
+.button--secondary {
+  color:#333;
+}

--- a/www/src/css/snap.css
+++ b/www/src/css/snap.css
@@ -33,7 +33,6 @@
 
 .b-snap__actions .b-installer {
   margin:0 10px;
-  width:auto;
 }
 
 .b-snap__navigation {
@@ -101,8 +100,6 @@
   }
 
   .b-snap__actions .b-installer {
-    margin-left:auto;
     margin-right:15px;
-    width:100px;
   }
 }

--- a/www/src/js/behaviors/install.js
+++ b/www/src/js/behaviors/install.js
@@ -11,6 +11,7 @@ module.exports = Marionette.Behavior.extend({
 
   modelEvents: {
     'change:installHTMLClass': 'onHTMLClassChange',
+    'change:installButtonClass': 'onButtonClassChange',
     'change:status': 'onStatusChange',
     'change:progress': 'onProgressChange'
   },
@@ -27,6 +28,12 @@ module.exports = Marionette.Behavior.extend({
     var installer = this.ui.installer;
     installer.removeClass(model.previous('installHTMLClass'))
     .addClass(model.get('installHTMLClass'));
+  },
+
+  onButtonClassChange: function(model) {
+    var button = this.ui.installerButton;
+    button.removeClass(model.previous('installButtonClass'))
+    .addClass(model.get('installButtonClass'));
   },
 
   onStatusChange: function(model) {

--- a/www/src/js/models/snap.js
+++ b/www/src/js/models/snap.js
@@ -124,13 +124,13 @@ module.exports = Backbone.Model.extend({
 
     switch (state) {
       case CONF.INSTALL_STATE.INSTALLED:
-        action = 'Remove';
+        action = 'Remove snap';
         break;
       case CONF.INSTALL_STATE.INSTALLING:
         action = 'Installing…';
         break;
       case CONF.INSTALL_STATE.REMOVED:
-        action = 'Install';
+        action = 'Install this snap';
         break;
       case CONF.INSTALL_STATE.REMOVING:
         action = 'Removing…';

--- a/www/src/js/models/snap.js
+++ b/www/src/js/models/snap.js
@@ -90,6 +90,7 @@ module.exports = Backbone.Model.extend({
   onStatusChange: function(model) {
     this.setInstallActionString(model);
     this.setInstallHTMLClass(model);
+    this.setInstallButtonClass(model);
   },
 
   // XXX move to install behaviour
@@ -142,6 +143,23 @@ module.exports = Backbone.Model.extend({
     }
 
     return model.set('installActionString', action);
+  },
+
+  setInstallButtonClass: function(model) {
+    var state = model.get('status');
+    var installButtonClass;
+
+    switch (state) {
+      case CONF.INSTALL_STATE.INSTALLED:
+      case CONF.INSTALL_STATE.INSTALLING:
+        installButtonClass = 'button--secondary';
+        break;
+      case CONF.INSTALL_STATE.REMOVED:
+      case CONF.INSTALL_STATE.REMOVING:
+        installButtonClass = 'button--primary';
+    }
+
+    return model.set('installButtonClass', installButtonClass);
   },
 
   parse: function(response) {

--- a/www/src/js/templates/_installer.hbs
+++ b/www/src/js/templates/_installer.hbs
@@ -1,21 +1,19 @@
 {{#if isInstallable}}
-<div class="b-installer {{ installHTMLClass }}">
-{{#if installActionString}}
-<div class="b-installer__button">{{ installActionString }}</div>
-<div class="b-installer__progress" title="download progress">
-<div class="b-installer__value"></div>
-</div>
-{{/if}}
-<div class="b-installer__message"></div>
-</div>
+  <div class="b-installer {{ installHTMLClass }}">
+    {{#if installActionString}}
+      <button class="b-installer__button {{ buttonClass }} {{ installButtonClass }}">{{ installActionString }}</button>
+      <div class="b-installer__progress" title="download progress">
+      <div class="b-installer__value"></div>
+      </div>
+    {{/if}}
+    <div class="b-installer__message"></div>
+  </div>
 {{else}}
-<div class="b-installer b-installer_disabled {{ installHTMLClass }}">
-<div class="b-installer__button">
-{{#if isInstalled}}
-Installed
-{{else}}
-Not installable
-{{/if}}
-</div>
-</div>
+  <div class="b-installer b-installer_disabled {{ installHTMLClass }}">
+    {{#if isInstalled}}
+      <button class="b-installer__button button--secondary {{ buttonClass }}">Installed</button>
+    {{else}}
+      <button class="b-installer__button button--secondary {{ buttonClass }}">Not installable</button>
+    {{/if}}
+  </div>
 {{/if}}

--- a/www/src/js/templates/snap-layout.hbs
+++ b/www/src/js/templates/snap-layout.hbs
@@ -11,7 +11,7 @@
         <div class="b-snap__developer">{{ developer }}</div>
       </div>
       <div class="b-snap__actions four-col last-col">
-        {{> installer}}
+        {{> installer buttonClass="b-installer__button_large"}}
       </div>
     </div>
   </div>

--- a/www/tests/modelSpec.js
+++ b/www/tests/modelSpec.js
@@ -90,6 +90,31 @@ describe('Snap', function() {
 
   });
 
+  describe('setInstallButtonClass', function() {
+
+    beforeEach(function() {
+      this.model = new Snap({id: 'foo'});
+    });
+
+    afterEach(function() {
+      delete this.model;
+    });
+
+    it('sets installButtonClass from the model state', function() {
+      this.model.set('status', CONF.INSTALL_STATE.INSTALLED);
+      expect(this.model.get('installButtonClass')).toBe('button--secondary');
+
+      this.model.set('status', CONF.INSTALL_STATE.REMOVED);
+      expect(this.model.get('installButtonClass')).toBe('button--primary');
+
+      this.model.set('status', CONF.INSTALL_STATE.REMOVING);
+      expect(this.model.get('installButtonClass')).toBe('button--primary');
+
+      this.model.set('status', CONF.INSTALL_STATE.INSTALLING);
+      expect(this.model.get('installButtonClass')).toBe('button--secondary');
+    });
+  });
+
   describe('sync methods', function() {
 
     beforeEach(function() {

--- a/www/tests/modelSpec.js
+++ b/www/tests/modelSpec.js
@@ -43,10 +43,10 @@ describe('Snap', function() {
 
     it('should set installActionString from model state', function() {
       this.model.set('status', CONF.INSTALL_STATE.INSTALLED);
-      expect(this.model.get('installActionString')).toBe('Remove');
+      expect(this.model.get('installActionString')).toBe('Remove snap');
 
       this.model.set('status', CONF.INSTALL_STATE.REMOVED);
-      expect(this.model.get('installActionString')).toBe('Install');
+      expect(this.model.get('installActionString')).toBe('Install this snap');
 
       this.model.set('status', CONF.INSTALL_STATE.REMOVING);
       expect(this.model.get('installActionString')).toBe('Removing…');


### PR DESCRIPTION
Depends on #18 and #20 landing so it's the last 5 commits that are relevant. #20 contains screenshots of the existing button style for comparison.

I'm interested to hear @bartaz's opinion on the use of both the `vf-buttons` module from Vanilla and the inclusion of some button CSS from Juju. We may well be able to drop this extra styling.

# Installed snaps that can be removed
![image](https://cloud.githubusercontent.com/assets/45121/16426122/f592bac4-3d91-11e6-90a1-e447aee1fc66.png)

# Installed snaps that cannot be removed
![image](https://cloud.githubusercontent.com/assets/45121/16426147/0a1d3e38-3d92-11e6-928f-481eebe463e0.png)

# Available snaps that can be installed
![image](https://cloud.githubusercontent.com/assets/45121/16426291/952a9868-3d92-11e6-89af-8c4ffd820358.png)

# Available snaps that cannot be installed
![image](https://cloud.githubusercontent.com/assets/45121/16426199/37bca7f2-3d92-11e6-977c-7ab690ac8fa8.png)

# The store (which will soon change)
![image](https://cloud.githubusercontent.com/assets/45121/16426230/4bcb9960-3d92-11e6-8c8d-fae29b3ffe4e.png)
