### PR TITLE
Remove progress tracking

### DIFF
--- a/www/src/css/installer.css
+++ b/www/src/css/installer.css
@@ -25,9 +25,3 @@
 .b-installer_thinking .b-installer__button {
   cursor:progress;
 }
-
-.b-installer__message {
-  margin-top:4px;
-  text-align:center;
-  font-size:12px;
-}

--- a/www/src/css/installer.css
+++ b/www/src/css/installer.css
@@ -31,31 +31,3 @@
   text-align:center;
   font-size:12px;
 }
-
-.b-installer__progress {
-  background: white;
-  border-radius:10px;
-  border:1px solid #dd4814;
-  bottom:0;
-  display:none;
-  height:5px;
-  left:0;
-  margin:0;
-  padding:0;
-  position:absolute;
-  right:0;
-}
-
-.b-installer__value {
-  background-color:rgba(221, 72, 20, 1);
-  bottom:0;
-  left:0;
-  position:absolute;
-  right:100%;
-  top:0;
-  transition: right 0.1s;
-}
-
-.b-installer_thinking .b-installer__progress {
-  display:block;
-}

--- a/www/src/js/behaviors/install.js
+++ b/www/src/js/behaviors/install.js
@@ -12,16 +12,14 @@ module.exports = Marionette.Behavior.extend({
   modelEvents: {
     'change:installHTMLClass': 'onHTMLClassChange',
     'change:installButtonClass': 'onButtonClassChange',
-    'change:status': 'onStatusChange',
-    'change:progress': 'onProgressChange'
+    'change:status': 'onStatusChange'
   },
 
   ui: {
     errorMessage: '.b-installer__error',
     statusMessage: '.b-installer__message',
     installer: '.b-installer',
-    installerButton: '.b-installer__button',
-    installerProgress: '.b-installer__value'
+    installerButton: '.b-installer__button'
   },
 
   onHTMLClassChange: function(model) {
@@ -42,9 +40,6 @@ module.exports = Marionette.Behavior.extend({
     var msg = model.get('installActionString');
     var installer = this.ui.installer;
     var installerButton = this.ui.installerButton;
-
-    // reset progress
-    this.ui.installerProgress.css('right', '100%');
 
     if (_.contains(CONF.INSTALL_STATE, state)) {
       installerButton.text(msg);
@@ -68,16 +63,6 @@ module.exports = Marionette.Behavior.extend({
       oldState === CONF.INSTALL_STATE.REMOVING
     ) {
       this.ui.statusMessage.text('Snap removed!');
-    }
-  },
-
-  onProgressChange: function(model) {
-    var state = model.get('status');
-    var progress;
-
-    if (state === CONF.INSTALL_STATE.INSTALLING) {
-      progress = (100 - (model.get('progress') | 0)) + '%';
-      this.ui.installerProgress.css('right', progress);
     }
   },
 

--- a/www/src/js/behaviors/install.js
+++ b/www/src/js/behaviors/install.js
@@ -17,7 +17,6 @@ module.exports = Marionette.Behavior.extend({
 
   ui: {
     errorMessage: '.b-installer__error',
-    statusMessage: '.b-installer__message',
     installer: '.b-installer',
     installerButton: '.b-installer__button'
   },
@@ -47,22 +46,6 @@ module.exports = Marionette.Behavior.extend({
       // in the rare case that a status isn't one we're expecting,
       // remove the install button
       installer.remove();
-    }
-
-    if (
-      state === CONF.INSTALL_STATE.INSTALLED &&
-      oldState === CONF.INSTALL_STATE.INSTALLING
-    ) {
-      this.ui.statusMessage.text('Install successful!');
-    } else {
-      this.ui.statusMessage.text('');
-    }
-
-    if (
-      state === CONF.INSTALL_STATE.REMOVED &&
-      oldState === CONF.INSTALL_STATE.REMOVING
-    ) {
-      this.ui.statusMessage.text('Snap removed!');
     }
   },
 

--- a/www/src/js/templates/_installer.hbs
+++ b/www/src/js/templates/_installer.hbs
@@ -3,7 +3,6 @@
     {{#if installActionString}}
       <button class="b-installer__button {{ buttonClass }} {{ installButtonClass }}">{{ installActionString }}</button>
     {{/if}}
-    <div class="b-installer__message"></div>
   </div>
 {{else}}
   <div class="b-installer b-installer_disabled {{ installHTMLClass }}">

--- a/www/src/js/templates/_installer.hbs
+++ b/www/src/js/templates/_installer.hbs
@@ -2,9 +2,6 @@
   <div class="b-installer {{ installHTMLClass }}">
     {{#if installActionString}}
       <button class="b-installer__button {{ buttonClass }} {{ installButtonClass }}">{{ installActionString }}</button>
-      <div class="b-installer__progress" title="download progress">
-      <div class="b-installer__value"></div>
-      </div>
     {{/if}}
     <div class="b-installer__message"></div>
   </div>


### PR DESCRIPTION
There's nothing in the new design to indicate the status of a snap installation or removal and for the time being there's no way of tracking progress of these operations. Remove the relevant JS, CSS and HTML.