### PR TITLE
Show installed snaps in store listing

### DIFF
--- a/snappy/converge.go
+++ b/snappy/converge.go
@@ -81,6 +81,28 @@ func (h *Handler) getSnap(name string) (*client.Snap, error) {
 	return snap, nil
 }
 
+func (h *Handler) augmentAvailableWithInstalled(available, installed []*client.Snap) []*client.Snap {
+	indexOfSnap := func(snap *client.Snap, snaps []*client.Snap) int {
+		for i, s := range snaps {
+			if s.Name == snap.Name {
+				return i
+			}
+		}
+		return -1
+	}
+
+	augmented := make([]*client.Snap, len(available))
+	for i, s := range available {
+		if idx := indexOfSnap(s, installed); idx > -1 {
+			augmented[i] = installed[idx]
+		} else {
+			augmented[i] = s
+		}
+	}
+
+	return augmented
+}
+
 func (h *Handler) packagePayload(resource string) (snapPkg, error) {
 	snap, err := h.getSnap(resource)
 	if err != nil {

--- a/snappy/converge_test.go
+++ b/snappy/converge_test.go
@@ -159,6 +159,43 @@ func (s *PayloadSuite) TestPayloadSnapInstalling(c *C) {
 	c.Assert(payload.Status, Equals, statustracker.StatusInstalling)
 }
 
+type AugmentSuite struct {
+	h Handler
+}
+
+var _ = Suite(&AugmentSuite{})
+
+func (s *AugmentSuite) TestAugmentSideloadedSnap(c *C) {
+	available := []*client.Snap{
+		newSnap("app1"),
+	}
+	installed := []*client.Snap{
+		newSnap("app2"),
+	}
+	merged := s.h.augmentAvailableWithInstalled(available, installed)
+
+	c.Assert(merged, HasLen, 1)
+	c.Assert(merged[0].Name, Equals, "app1")
+}
+
+func (s *AugmentSuite) TestAugmentInstalledSnap(c *C) {
+	available := []*client.Snap{
+		newSnap("app1"),
+		newSnap("app2"),
+	}
+	installedSnap := newSnap("app2")
+	installedSnap.Version = "0.0.1"
+	installed := []*client.Snap{
+		installedSnap,
+	}
+	merged := s.h.augmentAvailableWithInstalled(available, installed)
+
+	c.Assert(merged, HasLen, 2)
+	c.Assert(merged[0].Name, Equals, "app1")
+	c.Assert(merged[1].Name, Equals, "app2")
+	c.Assert(merged[1].Version, Equals, "0.0.1")
+}
+
 type AllPackagesSuite struct {
 	c *FakeSnapdClient
 	h Handler

--- a/snappy/fake_snapd_client.go
+++ b/snappy/fake_snapd_client.go
@@ -23,13 +23,13 @@ import (
 
 // FakeSnapdClient is a fake SnapdClient for testing purposes
 type FakeSnapdClient struct {
-	Snaps           []*client.Snap
-	StoreSnaps      []*client.Snap
-	Err             error
-	StoreErr        error
-	CalledListSnaps bool
-	Query           string
-	Version         string
+	Snaps      []*client.Snap
+	StoreSnaps []*client.Snap
+	Err        error
+	StoreErr   error
+	CalledFind bool
+	Query      string
+	Version    string
 }
 
 // Icon returns the icon of an installed snap
@@ -51,13 +51,12 @@ func (f *FakeSnapdClient) Snap(name string) (*client.Snap, *client.ResultInfo, e
 
 // List lists the installed snaps
 func (f *FakeSnapdClient) List(names []string) ([]*client.Snap, error) {
-	f.CalledListSnaps = true
-
 	return f.Snaps, f.Err
 }
 
 // Find returns the results of searching for snaps with the given options
 func (f *FakeSnapdClient) Find(opts *client.FindOptions) ([]*client.Snap, *client.ResultInfo, error) {
+	f.CalledFind = true
 	f.Query = opts.Query
 
 	return f.StoreSnaps, nil, f.StoreErr

--- a/snappy/handlers_test.go
+++ b/snappy/handlers_test.go
@@ -46,14 +46,14 @@ func (s *HandlersSuite) resetFakeSnapdClient() {
 
 func (s *HandlersSuite) TestGetAll(c *C) {
 	tests := []struct {
-		URL             string
-		CalledListSnaps bool
-		Query           string
+		URL        string
+		CalledFind bool
+		Query      string
 	}{
-		{"/", false, ""},
-		{"/?installed_only=true", true, ""},
-		{"/?q=foo", false, "foo"},
-		{"/?installed_only=true&q=foo", true, ""},
+		{"/", true, ""},
+		{"/?installed_only=true", false, ""},
+		{"/?q=foo", true, "foo"},
+		{"/?installed_only=true&q=foo", false, ""},
 	}
 
 	for _, tt := range tests {
@@ -64,7 +64,7 @@ func (s *HandlersSuite) TestGetAll(c *C) {
 		c.Assert(err, IsNil)
 
 		s.h.getAll(rec, req)
-		c.Assert(s.c.CalledListSnaps, Equals, tt.CalledListSnaps)
+		c.Assert(s.c.CalledFind, Equals, tt.CalledFind)
 		c.Assert(s.c.Query, Equals, tt.Query)
 	}
 }


### PR DESCRIPTION
The `/v2/find` endpoint in the `snapd` API now only returns the list of snaps available on the store, there's no longer an indication wether or not any of these snaps are currently installed.

This PR augments the list of available snaps with the list of installed ones so the user can see which are already installed when browsing the store.
