### PR TITLE
Bubble up store authentication errors from the client to JS app

### DIFF
--- a/snappy/handlers.go
+++ b/snappy/handlers.go
@@ -47,6 +47,14 @@ func (h *Handler) setClient(c SnapdClient) {
 	h.snapdClient = c
 }
 
+func (h *Handler) handleAuthError(err error, w http.ResponseWriter) bool {
+	if e, ok := err.(*client.Error); ok && e.StatusCode == http.StatusUnauthorized {
+		w.WriteHeader(http.StatusUnauthorized)
+		return true
+	}
+	return false
+}
+
 func (h *Handler) jsonResponseOrError(v interface{}, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 	enc := json.NewEncoder(w)
@@ -80,6 +88,10 @@ func (h *Handler) getAll(w http.ResponseWriter, r *http.Request) {
 	query := r.FormValue("q")
 
 	payload, err := h.allPackages(snapCondition, query)
+	if h.handleAuthError(err, w) {
+		return
+	}
+
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, "Error: %s", err)
@@ -93,6 +105,10 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
 
 	payload, err := h.packagePayload(name)
+	if h.handleAuthError(err, w) {
+		return
+	}
+
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprintln(w, err, name)
@@ -106,6 +122,9 @@ func (h *Handler) add(w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
 
 	err := h.installPackage(name)
+	if h.handleAuthError(err, w) {
+		return
+	}
 
 	h.snapOperationResponse(name, err, w)
 }

--- a/snappy/handlers_test.go
+++ b/snappy/handlers_test.go
@@ -24,6 +24,8 @@ import (
 	"net/http/httptest"
 	"os"
 
+	"github.com/snapcore/snapd/client"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -42,6 +44,29 @@ func (s *HandlersSuite) SetUpTest(c *C) {
 func (s *HandlersSuite) resetFakeSnapdClient() {
 	s.c = &FakeSnapdClient{}
 	s.h.setClient(s.c)
+}
+
+func (s *HandlersSuite) TestStoreAuthError(c *C) {
+	s.c.Err = errors.New("snap not found locally")
+	s.c.StoreErr = &client.Error{StatusCode: http.StatusUnauthorized}
+
+	tests := []struct {
+		Verb string
+		URL  string
+	}{
+		{"GET", "/"},
+		{"GET", "/foo"},
+		{"PUT", "/foo"},
+	}
+
+	for _, tt := range tests {
+		rec := httptest.NewRecorder()
+		req, err := http.NewRequest(tt.Verb, tt.URL, nil)
+		c.Assert(err, IsNil)
+
+		s.h.MakeMuxer("").ServeHTTP(rec, req)
+		c.Assert(rec.Code, Equals, http.StatusUnauthorized, Commentf("Checking: %s %s", tt.Verb, tt.URL))
+	}
 }
 
 func (s *HandlersSuite) TestGetAll(c *C) {


### PR DESCRIPTION
The assumption here is that any store interaction via the `snapd` client will result in a 401 response if the user requires authentication.

This first step towards having **snapweb** deal with the SSO dance and Macaroons is to alert the front-end app to 401 responses coming back from `snapd`.

Following on from this would be:

* get the JS app to redirect the browser to SSO
* deal with the callback containing the root and discharge Macaroons
* pass the Macaroons to `snapd` to store for future interactions with the store