### PR TITLE
[WIP] Redirect to SSO when the backend returns a 401 response

### DIFF
--- a/www/src/js/app.js
+++ b/www/src/js/app.js
@@ -6,6 +6,8 @@ var Backbone = require('backbone');
 Backbone.$ = $;
 var Marionette = require('backbone.marionette');
 var Radio = require('backbone.radio');
+var chan = Radio.channel('root');
+var CONF = require('./config.js');
 if (window.__agent) {
   window.__agent.start(Backbone, Marionette);
 }
@@ -22,4 +24,8 @@ $(document).ready(function() {
 
 snapweb.on('start', function() {
   Backbone.history.start({pushState: true});
+});
+
+chan.comply('redirect:sso', function() {
+  window.location = CONF.SSO_URL;
 });

--- a/www/src/js/collections/snaplist.js
+++ b/www/src/js/collections/snaplist.js
@@ -4,6 +4,8 @@
 var Backbone = require('backbone');
 var Snap = require('../models/snap.js');
 var CONF = require('../config.js');
+var Radio = require('backbone.radio');
+var chan = Radio.channel('root');
 
 module.exports = Backbone.Collection.extend({
   url: CONF.PACKAGES,
@@ -13,5 +15,12 @@ module.exports = Backbone.Collection.extend({
   },
   comparator: function(model) {
     return model.get('name');
+  },
+  initialize: function() {
+    this.on('error', function(collection, response) {
+      if (response.status == 401) {
+        chan.command('redirect:sso');
+      }
+    });
   }
 });

--- a/www/src/js/config.js
+++ b/www/src/js/config.js
@@ -1,6 +1,7 @@
 module.exports = {
   PACKAGES: '/api/v2/packages/',
   SETTINGS: '/api/v2/packages/ubuntu-core',
+  SSO_URL: 'http://google.com', // XXX
   FILTERED_SNAPS: [
     'snapweb',
     'ubuntu-core'

--- a/www/src/js/controllers/snaps.js
+++ b/www/src/js/controllers/snaps.js
@@ -17,10 +17,6 @@ module.exports = {
           model: snap
         });
         rootChannel.command('set:content', view);
-      },
-      error: function() {
-        // TODO error view
-        alert('Model.fetch() failed. :(');
       }
     });
   }

--- a/www/src/js/models/snap.js
+++ b/www/src/js/models/snap.js
@@ -45,6 +45,11 @@ module.exports = Backbone.Model.extend({
     });
 
     this.on('error', function(model, response, opts) {
+      if (response.status == 401) {
+        chan.command('redirect:sso');
+        return;
+      }
+
       var json = JSON.parse(response.responseText);
       var previous = model.previousAttributes();
       var message;

--- a/www/tests/modelSpec.js
+++ b/www/tests/modelSpec.js
@@ -2,6 +2,8 @@ var _ = require('lodash');
 var Snap = require('../src/js/models/snap.js');
 var Backbone = require('backbone');
 var CONF = require('../src/js/config.js');
+var Radio = require('backbone.radio');
+var chan = Radio.channel('root');
 
 describe('Snap', function() {
 
@@ -156,6 +158,19 @@ describe('Snap', function() {
         'contentType': 'application/json',
         'responseText': '{}'
       });
+    });
+
+    it('redirects to SSO on authentication error', function() {
+      var redirects = 0;
+      chan.comply('redirect:sso', function() {
+        redirects++;
+      });
+
+      this.model.save();
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        'status': 401
+      });
+      expect(redirects).toBe(1);
     });
   });
 });

--- a/www/tests/snaplistSpec.js
+++ b/www/tests/snaplistSpec.js
@@ -1,4 +1,6 @@
 var SnapList = require('../src/js/collections/snaplist.js');
+var Radio = require('backbone.radio');
+var chan = Radio.channel('root');
 
 describe('Snaplist', function() {
 
@@ -20,6 +22,31 @@ describe('Snaplist', function() {
       expect(installed.at(0).id).toBe('bar');
     });
 
+  });
+
+  describe('fetch', function() {
+
+    beforeEach(function() {
+      jasmine.Ajax.install();
+      this.list = new SnapList();
+    });
+
+    afterEach(function() {
+      jasmine.Ajax.uninstall();
+    });
+
+    it('redirects to SSO on authentication error', function() {
+      var redirects = 0;
+      chan.comply('redirect:sso', function() {
+        redirects++;
+      });
+
+      this.list.fetch();
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        'status': 401
+      });
+      expect(redirects).toBe(1);
+    });
   });
 
 });


### PR DESCRIPTION
Still need to get access to an instance of SSO to manually run all the authentication/Macaroon code against.

Upon accessing the model and receiving a 401 response this will use a channel to trigger a redirect to SSO.