### PR TITLE
Make the snap grid 2 cards wide on smaller viewports

### DIFF
--- a/www/src/css/lib/vanilla-overrides.scss
+++ b/www/src/css/lib/vanilla-overrides.scss
@@ -62,3 +62,26 @@
 .button--secondary {
   color:#333;
 }
+
+// scss/modules/_grid.scss
+.b-snaplist__item.three-col {
+  @include column-spacing(6);
+}
+
+.b-snaplist__item.three-col:nth-child(even) {
+  margin-right:0;
+}
+
+@media screen and (min-width: 640px) {
+  .b-snaplist__item.three-col {
+    @include column-spacing(3);
+  }
+
+  .b-snaplist__item.three-col:nth-child(even) {
+    @include column-spacing(3);
+  }
+
+  .b-snaplist__item.three-col:nth-child(4n) {
+    margin-right:0;
+  }
+}

--- a/www/src/js/views/snaplist-item.js
+++ b/www/src/js/views/snaplist-item.js
@@ -19,11 +19,6 @@ module.exports = Marionette.ItemView.extend({
     if (type) {
       className += ' b-snaplist__item-' + type;
     }
-    // each snap occupies 3 columns of the 12 column grid, we need to know which
-    // sits in the last column in each row
-    if (this.options.lastCol) {
-      className += ' last-col';
-    }
 
     return className;
   },

--- a/www/src/js/views/snaplist.js
+++ b/www/src/js/views/snaplist.js
@@ -69,14 +69,6 @@ module.exports = Marionette.CompositeView.extend({
     this.$('#styleRow').addClass('b-button_active');
   },
 
-  childViewOptions: function(model, index) {
-    var lastCol = (index != 0 && ((index + 1) % 4) == 0);
-
-    return {
-      lastCol: lastCol
-    };
-  },
-
   childView: SnaplistItemView,
 
   emptyView: EmptySnaplistView


### PR DESCRIPTION
LP: [#1605225](https://bugs.launchpad.net/snapweb/+bug/1605225)

This approach does away with the previous effort at adding a `last-col` class to every 4th card relying instead on `nth-child` selectors to remove the right margin where appropriate.

This is maybe something @bartaz will have an opinion on.

![image](https://cloud.githubusercontent.com/assets/45121/17146276/b7158180-5355-11e6-9127-f3aaeb0c7154.png)
