### PR TITLE
new gulp tasks to build snapweb and run; some livereload support (in …

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
       "underscore": "lodash"
     }
   },
+  "main": "gulpfile.js",
+  "scripts": {
+    "start": "gulp"
+  },  
   "dependencies": {
     "aliasify": "~1.7.2",
     "autoprefixer-core": "^5.1.11",
@@ -25,6 +29,9 @@
     "gulp-sourcemaps": "~1.5.0",
     "gulp-uglify": "~1.1.0",
     "gulp-util": "~3.0.4",
+    "gulp-golang": "https://github.com/cescoferraro/gulp-golang",
+    "gulp-livereload": "^3.8.1",
+    "gulp-sequence": "^0.4.6",
     "handlebars": "~3.0.0",
     "hbsfy": "~2.2.1",
     "istanbul": "^0.4.3",


### PR DESCRIPTION
New gulp tasks to build snapweb and run; see gulpfile.js
Livereload'ing the go server works. However it doesn't sync with the JS watch.
