### PR TITLE
Add (and use) a snapd client adapter.

### DIFF
--- a/cmd/snapweb/handlers.go
+++ b/cmd/snapweb/handlers.go
@@ -25,8 +25,6 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/snapcore/snapd/client"
-
 	"github.com/snapcore/snapweb/snappy"
 )
 
@@ -43,7 +41,7 @@ type templateData struct {
 var newSnapdClient = newSnapdClientImpl
 
 func newSnapdClientImpl() snappy.SnapdClient {
-	return client.New(nil)
+	return snappy.NewClientAdapter()
 }
 
 func getSnappyVersion() string {

--- a/snappy/handlers.go
+++ b/snappy/handlers.go
@@ -23,7 +23,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapweb/statustracker"
 
 	"github.com/gorilla/mux"
@@ -39,7 +38,7 @@ type Handler struct {
 func NewHandler() *Handler {
 	return &Handler{
 		statusTracker: statustracker.New(),
-		snapdClient:   client.New(nil),
+		snapdClient:   NewClientAdapter(),
 	}
 }
 

--- a/snappy/snapd_client.go
+++ b/snappy/snapd_client.go
@@ -31,3 +31,54 @@ type SnapdClient interface {
 	Remove(name string, options *client.SnapOptions) (string, error)
 	ServerVersion() (*client.ServerVersion, error)
 }
+
+// ClientAdapter adapts our expectations to the snapd client API.
+type ClientAdapter struct {
+	snapdClient *client.Client
+}
+
+// NewClientAdapter creates a new ClientAdapter for use in snapweb.
+func NewClientAdapter() *ClientAdapter {
+	return &ClientAdapter{
+		snapdClient: client.New(nil),
+	}
+}
+
+// Icon returns the Icon belonging to an installed snap.
+func (a *ClientAdapter) Icon(name string) (*client.Icon, error) {
+	return a.snapdClient.Icon(name)
+}
+
+// Snap returns the most recently published revision of the snap with the
+// provided name.
+func (a *ClientAdapter) Snap(name string) (*client.Snap, *client.ResultInfo, error) {
+	return a.snapdClient.Snap(name)
+}
+
+// List returns the list of all snaps installed on the system
+// with names in the given list; if the list is empty, all snaps.
+func (a *ClientAdapter) List(names []string) ([]*client.Snap, error) {
+	return a.snapdClient.List(names)
+}
+
+// Find returns a list of snaps available for install from the
+// store for this system and that match the query
+func (a *ClientAdapter) Find(opts *client.FindOptions) ([]*client.Snap, *client.ResultInfo, error) {
+	return a.snapdClient.Find(opts)
+}
+
+// Install adds the snap with the given name from the given channel (or
+// the system default channel if not).
+func (a *ClientAdapter) Install(name string, options *client.SnapOptions) (string, error) {
+	return a.snapdClient.Install(name, options)
+}
+
+// Remove removes the snap with the given name.
+func (a *ClientAdapter) Remove(name string, options *client.SnapOptions) (string, error) {
+	return a.snapdClient.Remove(name, options)
+}
+
+// ServerVersion returns information about the snapd server.
+func (a *ClientAdapter) ServerVersion() (*client.ServerVersion, error) {
+	return a.snapdClient.ServerVersion()
+}


### PR DESCRIPTION
With this change, snapweb development can proceed before relevant, but
expected, items are added to the snapd client API.