### PR TITLE
Add support for the create-user API

### DIFF
--- a/cmd/snapweb/handlers.go
+++ b/cmd/snapweb/handlers.go
@@ -20,7 +20,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -65,10 +64,9 @@ type timeInfoResponse struct {
 }
 
 func handleTimeInfo(w http.ResponseWriter, r *http.Request) {
-	c := newSnapdClient()
-
 	if r.Method == "GET" {
-		values, err := c.GetCoreConfig([]string{"Date", "Time", "Timezone", "NTPServer"})
+		values, err := snappy.GetCoreConfig(
+			[]string{"Date", "Time", "Timezone", "NTPServer"})
 		if err != nil {
 			log.Println("Error extracting core config", err)
 			return
@@ -87,20 +85,7 @@ func handleTimeInfo(w http.ResponseWriter, r *http.Request) {
 			log.Println("Error encoding time response", err)
 		}
 	} else if r.Method == "PATCH" {
-		data, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			log.Println("Error decoding time patch", err)
-			return
-		}
-
-		var timePatch map[string]interface{}
-		err = json.Unmarshal(data, &timePatch)
-		if err != nil {
-			log.Println("Error decoding time data", err)
-			return
-		}
-
-		c.SetCoreConfig(timePatch) // TODO: check result
+		w.WriteHeader(http.StatusNotImplemented)
 	}
 }
 

--- a/cmd/snapweb/handlers.go
+++ b/cmd/snapweb/handlers.go
@@ -93,6 +93,7 @@ func initURLHandlers(log *log.Logger) {
 	log.Println("Initializing HTTP handlers...")
 	snappyHandler := snappy.NewHandler()
 	http.Handle("/api/v2/packages/", snappyHandler.MakeMuxer("/api/v2/packages"))
+	http.HandleFunc("/api/v2/create-user", createUserHandler)
 
 	http.HandleFunc("/api/v2/time-info", handleTimeInfo)
 
@@ -105,6 +106,30 @@ func initURLHandlers(log *log.Logger) {
 	}
 
 	http.HandleFunc("/", makeMainPageHandler())
+}
+
+func createUserHandler(w http.ResponseWriter, r *http.Request) {
+	defer func() {
+		if r := recover(); r != nil {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}()
+
+	var createData client.CreateUserRequest
+
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&createData); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+	}
+
+	c := newSnapdClient()
+	user, _ := c.CreateUser(&createData)
+
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+
+	enc := json.NewEncoder(w)
+	enc.Encode(user)
 }
 
 func loggingHandler(h http.Handler) http.Handler {

--- a/cmd/snapweb/handlers.go
+++ b/cmd/snapweb/handlers.go
@@ -53,8 +53,6 @@ func unixDialer() func(string, string) (net.Conn, error) {
 	file, err := os.OpenFile(socketPath, os.O_RDWR, 0666)
 	if err == nil {
 		file.Close()
-	} else if e, ok := err.(*os.PathError); ok && (e.Err == syscall.ENOENT || e.Err == syscall.EACCES) {
-		socketPath = dirs.SnapSocket
 	}
 
 	return func(_, _ string) (net.Conn, error) {

--- a/cmd/snapweb/handlers.go
+++ b/cmd/snapweb/handlers.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"

--- a/cmd/snapweb/handlers.go
+++ b/cmd/snapweb/handlers.go
@@ -111,7 +111,7 @@ func initURLHandlers(log *log.Logger) {
 	log.Println("Initializing HTTP handlers...")
 	snappyHandler := snappy.NewHandler()
 	passThru := makePassthroughHandler(dirs.SnapdSocket, "/api")
-	
+
 	http.Handle("/api/v2/packages/", snappyHandler.MakeMuxer("/api/v2/packages"))
 	http.HandleFunc("/api/v2/create-user", passThru)
 
@@ -133,25 +133,25 @@ func makePassthroughHandler(socketPath string, prefix string) http.HandlerFunc {
 		c := &http.Client{
 			Transport: &http.Transport{Dial: unixDialer(socketPath)},
 		}
-		
+
 		// need to remove the RequestURI field
 		// and remove the /api prefix from snapweb URLs
 		r.URL.Scheme = "http"
 		r.URL.Host = "localhost"
 		r.URL.Path = strings.TrimPrefix(r.URL.Path, prefix)
-		
+
 		outreq, err := http.NewRequest(r.Method, r.URL.String(), r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		
+
 		resp, err := c.Do(outreq)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		
+
 		w.WriteHeader(resp.StatusCode)
 		io.Copy(w, resp.Body)
 	})

--- a/cmd/snapweb/handlers.go
+++ b/cmd/snapweb/handlers.go
@@ -20,14 +20,17 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"syscall"
 	"text/template"
 
-	// the CreateUser handler uses the snapd/client structures directly
-	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/dirs"
 
 	// most other handlers use the ClientAdapter for now
 	"github.com/snapcore/snapweb/snappy"
@@ -44,6 +47,20 @@ type templateData struct {
 }
 
 var newSnapdClient = newSnapdClientImpl
+
+func unixDialer() func(string, string) (net.Conn, error) {
+	socketPath := dirs.SnapdSocket
+	file, err := os.OpenFile(socketPath, os.O_RDWR, 0666)
+	if err == nil {
+		file.Close()
+	} else if e, ok := err.(*os.PathError); ok && (e.Err == syscall.ENOENT || e.Err == syscall.EACCES) {
+		socketPath = dirs.SnapSocket
+	}
+
+	return func(_, _ string) (net.Conn, error) {
+		return net.Dial("unix", socketPath)
+	}
+}
 
 func newSnapdClientImpl() snappy.SnapdClient {
 	return snappy.NewClientAdapter()
@@ -97,7 +114,7 @@ func initURLHandlers(log *log.Logger) {
 	log.Println("Initializing HTTP handlers...")
 	snappyHandler := snappy.NewHandler()
 	http.Handle("/api/v2/packages/", snappyHandler.MakeMuxer("/api/v2/packages"))
-	http.HandleFunc("/api/v2/create-user", createUserHandler)
+	http.HandleFunc("/api/v2/create-user", passthrough)
 
 	http.HandleFunc("/api/v2/time-info", handleTimeInfo)
 
@@ -112,35 +129,19 @@ func initURLHandlers(log *log.Logger) {
 	http.HandleFunc("/", makeMainPageHandler())
 }
 
-func createUserHandler(w http.ResponseWriter, r *http.Request) {
-	defer func() {
-		if r := recover(); r != nil {
-			w.WriteHeader(http.StatusBadRequest)
-		}
-	}()
-
-	var createData client.CreateUserRequest
-
-	decoder := json.NewDecoder(r.Body)
-	if err := decoder.Decode(&createData); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
+// FIXME: this needs a test
+func passthrough(w http.ResponseWriter, r *http.Request) {
+	c := &http.Client{
+		Transport: &http.Transport{Dial: unixDialer()},
 	}
-
-	log.Println("/api/v2/create-user", createData)
-
-	w.Header().Set("Content-Type", "application/json")
-	enc := json.NewEncoder(w)
-
-	c := newSnapdClient()
-	user, err := c.CreateUser(&createData)
+	resp, err := c.Do(r)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, "{ error: \"%v\" }", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
-	enc.Encode(user)
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
 }
 
 func loggingHandler(h http.Handler) http.Handler {

--- a/cmd/snapweb/handlers.go
+++ b/cmd/snapweb/handlers.go
@@ -26,6 +26,10 @@ import (
 	"path/filepath"
 	"text/template"
 
+	// the CreateUser handler uses the snapd/client structures directly
+	"github.com/snapcore/snapd/client"
+
+	// most other handlers use the ClientAdapter for now
 	"github.com/snapcore/snapweb/snappy"
 )
 
@@ -122,13 +126,20 @@ func createUserHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 	}
 
+	log.Println("/api/v2/create-user", createData)
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+
 	c := newSnapdClient()
-	user, _ := c.CreateUser(&createData)
+	user, err := c.CreateUser(&createData)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "{ error: \"%v\" }", err)
+		return
+	}
 
 	w.WriteHeader(http.StatusOK)
-	w.Header().Set("Content-Type", "application/json")
-
-	enc := json.NewEncoder(w)
 	enc.Encode(user)
 }
 

--- a/cmd/snapweb/handlers.go
+++ b/cmd/snapweb/handlers.go
@@ -27,7 +27,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"syscall"
 	"text/template"
 
 	"github.com/snapcore/snapd/dirs"

--- a/cmd/snapweb/handlers_test.go
+++ b/cmd/snapweb/handlers_test.go
@@ -33,7 +33,6 @@ import (
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapweb/snappy"
 )
 
@@ -191,10 +190,11 @@ func (s *HandlersSuite) TestRenderLayout(c *C) {
 }
 
 func (s *HandlersSuite) TestPassthroughHandler(c *C) {
-	c.Assert(os.MkdirAll(filepath.Dir(dirs.SnapdSocket), 0755), IsNil)
-	l, err := net.Listen("unix", dirs.SnapdSocket)
+	socketPath := "/tmp/snapd-test.socket"
+	c.Assert(os.MkdirAll(filepath.Dir(socketPath), 0755), IsNil)
+	l, err := net.Listen("unix", socketPath)
 	if err != nil {
-		c.Fatalf("unable to listen on %q: %v", dirs.SnapdSocket, err)
+		c.Fatalf("unable to listen on %q: %v", socketPath, err)
 	}
 
 	f := func(w http.ResponseWriter, r *http.Request) {
@@ -211,7 +211,7 @@ func (s *HandlersSuite) TestPassthroughHandler(c *C) {
 	srv.Start()
 	defer srv.Close()
 
-	handler := http.HandlerFunc(makePassthroughHandler("/tmp/snapd-test.socket", "/api"))
+	handler := http.HandlerFunc(makePassthroughHandler(socketPath, "/api"))
 
 	rec := httptest.NewRecorder()
 	req, err := http.NewRequest("GET", "/api/v2/system-info", nil)

--- a/cmd/snapweb/handlers_test.go
+++ b/cmd/snapweb/handlers_test.go
@@ -211,13 +211,14 @@ func (s *HandlersSuite) TestPassthroughHandler(c *C) {
 	srv.Start()
 	defer srv.Close()
 
-	handler := http.HandlerFunc(passthrough)
+	handler := http.HandlerFunc(makePassthroughHandler("/tmp/snapd-test.socket", "/api"))
 
 	rec := httptest.NewRecorder()
 	req, err := http.NewRequest("GET", "/api/v2/system-info", nil)
 	c.Assert(err, IsNil)
 
 	handler(rec, req)
+	body := rec.Body.String()
 	c.Assert(rec.Code, Equals, http.StatusOK)
-	/* ... */
+	c.Check(strings.Contains(body, "42"), Equals, true)
 }

--- a/cmd/snapweb/main.go
+++ b/cmd/snapweb/main.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014, 2015, 2016 Canonical Ltd
+ * Copyright (C) 2014-2016 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -2,7 +2,7 @@ github.com/cheggaaa/pb	git	e8c7cc515bfde3e267957a3b110080ceed51354e	2014-12-02T0
 github.com/gorilla/context	git	50c25fb3b2b3b3cc724e9b6ac75fb44b3bccd0da	2014-11-26T16:34:05Z
 github.com/gorilla/mux	git	e444e69cbd2e2e3e0749a2f3c717cec491552bbf	2014-09-26T15:38:14Z
 github.com/presotto/go-mdns-sd	git	343772046ec1b3840b8591799a7bbcc68ea47b4b	2015-11-03T06:16:58Z
-github.com/snapcore/snapd	git	fd85491fd46396fdf754a12cd2bfa75037371c17	2016-09-12T14:34:41Z
+github.com/snapcore/snapd	git	ee12a51909e87b30b684573a9012c2029ff1259c	2016-10-04T09:45:38Z
 golang.org/x/crypto	git	60052bd85f2d91293457e8811b0cf26b773de469	2015-06-22T23:34:07Z
 gopkg.in/check.v1	git	64131543e7896d5bcc6bd5a76287eb75ea96c673	2014-10-24T13:38:53Z
 gopkg.in/ini.v1	git	6e4869b434bd001f6983749881c7ead3545887d8	2016-08-27T06:11:18Z

--- a/snappy/fake_snapd_client.go
+++ b/snappy/fake_snapd_client.go
@@ -94,6 +94,7 @@ func (f *FakeSnapdClient) GetCoreConfig(keys []string) (map[string]interface{}, 
 	return nil, nil
 }
 
+// CreateUser creates a local user on the system
 func (f *FakeSnapdClient) CreateUser(request *client.CreateUserRequest) (*client.CreateUserResult, error) {
 	createResult := client.CreateUserResult{
 		Username:    "johndoe",

--- a/snappy/fake_snapd_client.go
+++ b/snappy/fake_snapd_client.go
@@ -84,4 +84,23 @@ func (f *FakeSnapdClient) ServerVersion() (*client.ServerVersion, error) {
 	return &f.Version, f.Err
 }
 
+// SetCoreConfig sets some aspect of core configuration
+func (f *FakeSnapdClient) SetCoreConfig(patch map[string]interface{}) (string, error) {
+	return "", nil
+}
+
+// GetCoreConfig gets some aspect of core configuration
+func (f *FakeSnapdClient) GetCoreConfig(keys []string) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (f *FakeSnapdClient) CreateUser(request *client.CreateUserRequest) (*client.CreateUserResult, error) {
+	createResult := client.CreateUserResult{
+		Username:    "johndoe",
+		SSHKeyCount: 1,
+	}
+
+	return &createResult, nil
+}
+
 var _ SnapdClient = (*FakeSnapdClient)(nil)

--- a/snappy/fake_snapd_client.go
+++ b/snappy/fake_snapd_client.go
@@ -96,7 +96,7 @@ func (f *FakeSnapdClient) GetCoreConfig(keys []string) (map[string]interface{}, 
 }
 
 // CreateUser creates a local user on the system
-func (f *FakeSnapdClient) CreateUser(request *client.CreateUserRequest) (*client.CreateUserResult, error) {
+func (f *FakeSnapdClient) CreateUser(request *client.CreateUserOptions) (*client.CreateUserResult, error) {
 	return &f.CrUser, f.Err
 }
 

--- a/snappy/fake_snapd_client.go
+++ b/snappy/fake_snapd_client.go
@@ -32,6 +32,7 @@ type FakeSnapdClient struct {
 	Version         client.ServerVersion
 	Installed       string
 	Removed         string
+	CrUser          client.CreateUserResult
 }
 
 // Icon returns the icon of an installed snap
@@ -96,12 +97,7 @@ func (f *FakeSnapdClient) GetCoreConfig(keys []string) (map[string]interface{}, 
 
 // CreateUser creates a local user on the system
 func (f *FakeSnapdClient) CreateUser(request *client.CreateUserRequest) (*client.CreateUserResult, error) {
-	createResult := client.CreateUserResult{
-		Username:    "johndoe",
-		SSHKeyCount: 1,
-	}
-
-	return &createResult, nil
+	return &f.CrUser, f.Err
 }
 
 var _ SnapdClient = (*FakeSnapdClient)(nil)

--- a/snappy/fake_snapd_client.go
+++ b/snappy/fake_snapd_client.go
@@ -84,14 +84,4 @@ func (f *FakeSnapdClient) ServerVersion() (*client.ServerVersion, error) {
 	return &f.Version, f.Err
 }
 
-// SetCoreConfig sets some aspect of core configuration
-func (f *FakeSnapdClient) SetCoreConfig(patch map[string]interface{}) (string, error) {
-	return "", nil
-}
-
-// GetCoreConfig gets some aspect of core configuration
-func (f *FakeSnapdClient) GetCoreConfig(keys []string) (map[string]interface{}, error) {
-	return nil, nil
-}
-
 var _ SnapdClient = (*FakeSnapdClient)(nil)

--- a/snappy/snapd_client.go
+++ b/snappy/snapd_client.go
@@ -124,3 +124,8 @@ func GetCoreConfig(keys []string) (map[string]interface{}, error) {
 		"NTPServer": readNTPServer(),
 	}, nil
 }
+
+// CreateUser creates a local user on the system
+func (a *ClientAdapter) CreateUser(request *client.CreateUserRequest) (*client.CreateUserResult, error) {
+	return a.snapdClient.CreateUser(request)
+}

--- a/snappy/snapd_client.go
+++ b/snappy/snapd_client.go
@@ -36,8 +36,6 @@ type SnapdClient interface {
 	Install(name string, options *client.SnapOptions) (string, error)
 	Remove(name string, options *client.SnapOptions) (string, error)
 	ServerVersion() (*client.ServerVersion, error)
-	SetCoreConfig(patch map[string]interface{}) (string, error)
-	GetCoreConfig(keys []string) (map[string]interface{}, error)
 	CreateUser(request *client.CreateUserOptions) (*client.CreateUserResult, error)
 }
 

--- a/snappy/snapd_client.go
+++ b/snappy/snapd_client.go
@@ -36,6 +36,9 @@ type SnapdClient interface {
 	Install(name string, options *client.SnapOptions) (string, error)
 	Remove(name string, options *client.SnapOptions) (string, error)
 	ServerVersion() (*client.ServerVersion, error)
+	SetCoreConfig(patch map[string]interface{}) (string, error)
+	GetCoreConfig(keys []string) (map[string]interface{}, error)
+	CreateUser(request *client.CreateUserRequest) (*client.CreateUserResult, error)
 }
 
 // ClientAdapter adapts our expectations to the snapd client API.

--- a/snappy/snapd_client.go
+++ b/snappy/snapd_client.go
@@ -38,7 +38,7 @@ type SnapdClient interface {
 	ServerVersion() (*client.ServerVersion, error)
 	SetCoreConfig(patch map[string]interface{}) (string, error)
 	GetCoreConfig(keys []string) (map[string]interface{}, error)
-	CreateUser(request *client.CreateUserRequest) (*client.CreateUserResult, error)
+	CreateUser(request *client.CreateUserOptions) (*client.CreateUserResult, error)
 }
 
 // ClientAdapter adapts our expectations to the snapd client API.
@@ -126,6 +126,6 @@ func GetCoreConfig(keys []string) (map[string]interface{}, error) {
 }
 
 // CreateUser creates a local user on the system
-func (a *ClientAdapter) CreateUser(request *client.CreateUserRequest) (*client.CreateUserResult, error) {
+func (a *ClientAdapter) CreateUser(request *client.CreateUserOptions) (*client.CreateUserResult, error) {
 	return a.snapdClient.CreateUser(request)
 }

--- a/snappy/snapd_client_test.go
+++ b/snappy/snapd_client_test.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snappy
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	. "gopkg.in/check.v1"
+)
+
+const timesyncFileName = "timesyncd.conf"
+
+func mockNTPFileContent(c *C, ntpFilePath string, content string) {
+	c.Assert(ioutil.WriteFile(ntpFilePath, []byte(content), 0644), IsNil)
+}
+
+func formatNTPContent(ntpServers []string) string {
+	return fmt.Sprintln(`
+[Time]
+NTP=`, strings.Join(ntpServers, " "))
+}
+
+type ReadNtpSuite struct {
+	ntpFilePath string
+}
+
+var _ = Suite(&ReadNtpSuite{})
+
+func (s *ReadNtpSuite) SetUpTest(c *C) {
+	s.ntpFilePath = c.MkDir()
+}
+
+func (s *ReadNtpSuite) TestReadNonExistentNTP(c *C) {
+	timesyncdConfigurationFilePath = filepath.Join(s.ntpFilePath, timesyncFileName)
+	c.Check(readNTPServer(), Equals, "")
+}
+
+func (s *ReadNtpSuite) TestReadInvalidNTP(c *C) {
+	timesyncdConfigurationFilePath = filepath.Join(s.ntpFilePath, timesyncFileName)
+	mockNTPFileContent(c, timesyncdConfigurationFilePath, "")
+	c.Check(readNTPServer(), Equals, "")
+	mockNTPFileContent(c, timesyncdConfigurationFilePath, "invalid")
+	c.Check(readNTPServer(), Equals, "")
+	mockNTPFileContent(c, timesyncdConfigurationFilePath, "[Time]\n")
+	c.Check(readNTPServer(), Equals, "")
+}
+
+func (s *ReadNtpSuite) TestReadValidNTP(c *C) {
+	timesyncdConfigurationFilePath = filepath.Join(s.ntpFilePath, timesyncFileName)
+	ntpServer := "1.1.1.1"
+	mockNTPFileContent(c,
+		timesyncdConfigurationFilePath,
+		formatNTPContent([]string{ntpServer}))
+	c.Check(readNTPServer(), Equals, ntpServer)
+}


### PR DESCRIPTION
(take 2, grmbl)
This is the first building block for the firstboot use-case, ie letting users create an account on a new ubuntu core device.