### PR TITLE
Fix golint by reverting to an older commit

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -66,7 +66,13 @@ if [ ! -z "$STATIC" ]; then
     go vet ./...
 
     echo Install golint
-    go get github.com/golang/lint/golint
+    go get -d github.com/golang/lint/golint
+    (
+        cd $GOPATH/src/github.com/golang/lint
+        # revert to the last commit before go 1.5 support was dropped
+        git checkout c6242afa6ced3be489e1184eb80bc2d85f1f5e7b .
+    )
+    go install github.com/golang/lint/golint
     export PATH=$PATH:$GOPATH/bin
 
     echo Running lint


### PR DESCRIPTION
Currently golint fails in Travis because of 
../../golang/lint/lint.go:250: undefined: types.ImportMode

Seems this is due by: 

commit a428635c58fe96360e83667e2e1a8343fc292bf0
Author: Alan Donovan <adonovan@google.com>
Date:   Thu Sep 15 18:32:00 2016 -0700

    Drop support for Go 1.5.
    
    Signed-off-by: Joe Tsai <joetsai@google.com>
