### PR TITLE
Adjustment to .jscsrc

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -11,7 +11,7 @@
     "requireOperatorBeforeLineBreak": true,
     "requireCamelCaseOrUpperCaseIdentifiers": true,
     "maximumLineLength": {
-      "value": 80,
+      "value": 120,
       "allowComments": true,
       "allowRegex": true
     },


### PR DESCRIPTION
The 80 column limit is backwards and restrictive, we no longer use 80 column terminals. While clear code standards are good, checks should only fail at the unresolvable margins, otherwise over enforcement leads to unexpected and inefficient outcomes.