### PR TITLE
Put a bit better defaults for device infos names

### DIFF
--- a/cmd/snapweb/handlers_test.go
+++ b/cmd/snapweb/handlers_test.go
@@ -264,9 +264,9 @@ func (s *HandlersSuite) TestModelInfoHandler(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(deviceInfos["deviceName"], Equals, "Device Name")
-	c.Assert(deviceInfos["brand"], Equals, "Brand")
-	c.Assert(deviceInfos["model"], Equals, "Model")
-	c.Assert(deviceInfos["serial"], Equals, "Serial Number")
+	c.Assert(deviceInfos["brand"], Equals, "Unknown")
+	c.Assert(deviceInfos["model"], Equals, "Unknown")
+	c.Assert(deviceInfos["serial"], Equals, "Unknown")
 }
 
 func (s *HandlersSuite) TestCheckCookieToken(c *C) {

--- a/snappy/snapd_client.go
+++ b/snappy/snapd_client.go
@@ -173,9 +173,9 @@ func GetModelInfo(c SnapdClient) (map[string]interface{}, error) {
 	deviceName := "Device Name"
 
 	// Model Info
-	brandName := "Brand"
-	modelName := "Model"
-	serialNumber := "Serial Number"
+	brandName := "Unknown"
+	modelName := "Unknown"
+	serialNumber := "Unknown"
 
 	serialInfo, err := c.Known("serial", map[string]string{})
 	if err == nil {


### PR DESCRIPTION
The device information comes from plain snapd, from the serial known interface. Snapd itself pulls it from the builtin or custom assertions it can find in the running system.
This PR just changes the defaults (that might not currently have the best value) since we cannot do much about the rest.