### PR TITLE
Manually connect interfaces on the test system

### DIFF
--- a/tests/remote-install-snap.sh
+++ b/tests/remote-install-snap.sh
@@ -15,3 +15,6 @@ ssh -p $port $user@$host "if [ -d tmpsnaps ]; then rm -rf tmpsnaps; fi; mkdir tm
 scp -P $port $snap  $user@$host:/home/$user/tmpsnaps/
 ssh -p $port $user@$host "sudo snap remove snapweb >/dev/null"
 ssh -p $port $user@$host "sudo snap install /home/$user/tmpsnaps/$snap_name --devmode"
+# need to manually connect interfaces as snapd won't do it anymore in devmode
+ssh -p $port $user@$host "sudo snap connect snapweb:snapd-control"
+ssh -p $port $user@$host "sudo snap connect snapweb:timeserver-control"


### PR DESCRIPTION
Because snapweb is installed in --devmode on the test system