### PR TITLE
WIP: Enable disable snap support

### DIFF
--- a/cmd/snapweb/api.go
+++ b/cmd/snapweb/api.go
@@ -20,6 +20,7 @@ package main
 import (
 	"net/http"
 	"path"
+	"strings"
 
 	"github.com/gorilla/mux"
 
@@ -41,7 +42,8 @@ func makeAPIHandler(apiRootPath string) http.Handler {
 	router.HandleFunc("/device-action", handleDeviceAction)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if SimpleCookieCheck(w, r) == nil {
+		if strings.HasPrefix(r.URL.Path, path.Join(apiPath, "packages/internal/")) ||
+			SimpleCookieCheck(w, r) == nil {
 			router.ServeHTTP(w, r)
 		} else {
 			// in any other case, refuse the request and redirect

--- a/snappy/app/converge.go
+++ b/snappy/app/converge.go
@@ -162,13 +162,13 @@ func (h *Handler) installPackage(name string) error {
 func (h *Handler) enable(name string) error {
 	snap, err := h.getSnap(name)
 	// TODO check State
-	if err != nil && snap != nil{
+	if err != nil && snap != nil {
 		return err
 	}
 
 	_, err = h.snapdClient.Enable(name, nil)
 
-//	h.stateTracker.TrackEnable(changeID, snap)
+	//	h.stateTracker.TrackEnable(changeID, snap)
 
 	return err
 }
@@ -182,7 +182,7 @@ func (h *Handler) disable(name string) error {
 
 	_, err = h.snapdClient.Disable(name, nil)
 
-//	h.stateTracker.TrackDisable(changeID, snap)
+	//	h.stateTracker.TrackDisable(changeID, snap)
 
 	return err
 }

--- a/snappy/app/converge.go
+++ b/snappy/app/converge.go
@@ -238,7 +238,10 @@ func (h *Handler) snapToPayload(snapQ *client.Snap) snapPkg {
 		InstallDate: formatInstallData(snapQ.InstallDate),
 	}
 
-	isInstalled := snapQ.Status == client.StatusInstalled || snapQ.Status == client.StatusActive
+	isInstalled := snapQ.Status == client.StatusInstalled ||
+		snapQ.Status == client.StatusActive ||
+		snapQ.Status == client.StatusEnabling ||
+		snapQ.Status == client.StatusDisabling
 
 	if isInstalled {
 		iconPath, err := localIconPath(h.snapdClient, snap.Name)

--- a/snappy/app/converge.go
+++ b/snappy/app/converge.go
@@ -159,6 +159,34 @@ func (h *Handler) installPackage(name string) error {
 	return err
 }
 
+func (h *Handler) enable(name string) error {
+	snap, err := h.getSnap(name)
+	// TODO check State
+	if err != nil && snap != nil{
+		return err
+	}
+
+	_, err = h.snapdClient.Enable(name, nil)
+
+//	h.stateTracker.TrackEnable(changeID, snap)
+
+	return err
+}
+
+func (h *Handler) disable(name string) error {
+	snap, err := h.getSnap(name)
+	// TODO check snap existence & state
+	if err != nil && snap != nil {
+		return err
+	}
+
+	_, err = h.snapdClient.Disable(name, nil)
+
+//	h.stateTracker.TrackDisable(changeID, snap)
+
+	return err
+}
+
 func formatInstallData(d time.Time) string {
 	// store snaps dont have install dates
 	// are their install date are time.Time zero values

--- a/snappy/app/fake_snapd_client.go
+++ b/snappy/app/fake_snapd_client.go
@@ -139,4 +139,14 @@ func (f *FakeSnapdClient) Change(id string) (*client.Change, error) {
 	return nil, nil
 }
 
+// Enable enables the snap
+func (f *FakeSnapdClient) Enable(name string, options *client.SnapOptions) (string, error) {
+	return "", nil
+}
+
+// Disable disables the snap
+func (f *FakeSnapdClient) Disable(name string, options *client.SnapOptions) (string, error) {
+	return "", nil
+}
+
 var _ snapdclient.SnapdClient = (*FakeSnapdClient)(nil)

--- a/snappy/app/handlers.go
+++ b/snappy/app/handlers.go
@@ -133,6 +133,37 @@ func (h *Handler) remove(w http.ResponseWriter, r *http.Request) {
 	h.snapOperationResponse(name, err, w)
 }
 
+func (h *Handler) internalSnap(w http.ResponseWriter, r *http.Request) {
+	snapName := mux.Vars(r)["name"]
+
+	if snapName == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	values := r.URL.Query()
+	var err error
+	var operation string
+	if operation = values.Get("operation"); operation == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+//	var changeID string
+
+	switch operation {
+	case "enable":
+		err = h.enable(snapName)
+	case "disable":
+		err = h.disable(snapName)
+	}
+	
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}
+
 // MakeMuxer sets up the handlers multiplexing to handle requests against snappy's
 // packages api
 func (h *Handler) MakeMuxer(prefix string, parentRouter *mux.Router) http.Handler {
@@ -149,6 +180,9 @@ func (h *Handler) MakeMuxer(prefix string, parentRouter *mux.Router) http.Handle
 
 	// Remove a package
 	m.HandleFunc("/{name}", h.remove).Methods("DELETE")
+
+	// Remove a package
+	m.HandleFunc("/internal/{name}", h.internalSnap).Methods("GET")
 
 	return m
 }

--- a/snappy/app/handlers.go
+++ b/snappy/app/handlers.go
@@ -149,7 +149,7 @@ func (h *Handler) internalSnap(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-//	var changeID string
+	//	var changeID string
 
 	switch operation {
 	case "enable":
@@ -157,7 +157,7 @@ func (h *Handler) internalSnap(w http.ResponseWriter, r *http.Request) {
 	case "disable":
 		err = h.disable(snapName)
 	}
-	
+
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/snappy/snapdclient/snapd_client.go
+++ b/snappy/snapdclient/snapd_client.go
@@ -45,6 +45,8 @@ type SnapdClient interface {
 	Interfaces() (client.Interfaces, error)
 	Known(assertTypeName string, headers map[string]string) ([]asserts.Assertion, error)
 	Change(id string) (*client.Change, error)
+	Enable(id string, options *client.SnapOptions) (string, error)
+	Disable(id string, options *client.SnapOptions) (string, error)
 }
 
 // ClientAdapter adapts our expectations to the snapd client API.
@@ -122,6 +124,16 @@ func (a *ClientAdapter) Sections() ([]string, error) {
 // Change returns the list of ongoing changes for a given snap and changeid
 func (a *ClientAdapter) Change(id string) (*client.Change, error) {
 	return a.snapdClient.Change(id)
+}
+
+// Enable enables the snap
+func (a *ClientAdapter) Enable(name string, options *client.SnapOptions) (string, error) {
+	return a.snapdClient.Enable(name, options)
+}
+
+// Disable disables the snap
+func (a *ClientAdapter) Disable(name string, options *client.SnapOptions) (string, error) {
+	return a.snapdClient.Disable(name, options)
 }
 
 // internal

--- a/statetracker/statetracker.go
+++ b/statetracker/statetracker.go
@@ -39,9 +39,9 @@ import (
 const (
 	// StatusPriced indicates the package is priced and has not been bought.
 	StatusPriced = "priced"
-	// StatusInstalled indicates the package is in an installed state.
+	// StatusInstalled indicates the package is in an installed state but disabled.
 	StatusInstalled = "installed"
-	// StatusActive indicates the package is in an installed but disabled state.
+	// StatusActive indicates the package is in an installed and enabled state.
 	StatusActive = "active"
 	// StatusUninstalled indicates the package is in an uninstalled state.
 	StatusUninstalled = "uninstalled"

--- a/statetracker/statetracker.go
+++ b/statetracker/statetracker.go
@@ -16,10 +16,11 @@
  */
 
 // Package statetracker enables the tracking of a limited amount
-// of snap states: installation/removal, current download progress during
-// install.
-//
-// Once a snap has been marked as "installing" it will remain in that
+// of snap states during long running snap operations:
+// - installation/removal (current download progress during install, ...)
+// - enabling/disabling of snaps,
+// 
+// Note: Once a snap has been marked as "installing" it will remain in that
 // state until it's status as provided by snapd indicates that it is installed
 // on the system. Similarly for removing snaps. Status lifecycle is thus:
 //
@@ -49,6 +50,10 @@ const (
 	StatusInstalling = "installing"
 	// StatusUninstalling indicates the package is in an uninstalling state.
 	StatusUninstalling = "uninstalling"
+	// StatusEnabling indicates the package is in an enabling state.
+	StatusEnabling = "enabling"
+	// StatusDisabling indicates the package is in an disabling state.
+	StatusDisabling = "disabling"
 )
 
 // TODO: naive approach to track big downloads
@@ -89,7 +94,7 @@ func (s *StateTracker) State(c snapdclient.SnapdClient, snap *client.Snap) *Snap
 		}
 	}
 
-	if changing, changeID := s.IsInstalling(snap); changing && c != nil {
+	if changing, changeID := s.IsTrackedForRunningOperation(snap); changing && c != nil {
 		change, err := c.Change(changeID)
 
 		if err == nil {
@@ -106,7 +111,7 @@ func (s *StateTracker) State(c snapdclient.SnapdClient, snap *client.Snap) *Snap
 		}
 	}
 
-	if hasCompleted(cstate.Status, snap) {
+	if hasOperationCompleted(cstate.Status, snap) {
 		delete(s.states, snap.Name)
 		return &SnapState{
 			Status: translateStatus(snap),
@@ -116,23 +121,67 @@ func (s *StateTracker) State(c snapdclient.SnapdClient, snap *client.Snap) *Snap
 	return &cstate
 }
 
+// IsTrackedForRunningOperation checks if a given snap is currently concerned by
+// by a running operation
+func (s *StateTracker) IsTrackedForRunningOperation(snap *client.Snap) (bool, string) {
+	state, ok := s.states[snap.Name]
+	if !ok {
+		return false, ""
+	}
+
+	return !hasOperationCompleted(state.Status, snap), state.ChangeID
+}
+
 // TrackInstall tracks the installation of the given snap
 func (s *StateTracker) TrackInstall(changeID string, snap *client.Snap) {
 	if isInstalled(snap) {
 		return
 	}
 
+	if tracked, _ := s.IsTrackedForRunningOperation(snap); tracked {
+		return
+	}
+
 	s.trackOperation(changeID, snap.Name, StatusInstalling)
 }
 
-// IsInstalling checks if a given snap is being installed
-func (s *StateTracker) IsInstalling(snap *client.Snap) (bool, string) {
-	state, ok := s.states[snap.Name]
-	if !ok {
-		return false, ""
+// TrackUninstall tracks the removal of the given snap
+func (s *StateTracker) TrackUninstall(changeID string, snap *client.Snap) {
+	if !isInstalled(snap) {
+		return
 	}
 
-	return !hasCompleted(state.Status, snap), state.ChangeID
+	if tracked, _ := s.IsTrackedForRunningOperation(snap); tracked {
+		return
+	}
+
+	s.trackOperation(changeID, snap.Name, StatusUninstalling)
+}
+
+// TrackEnable tracks the installation of the given snap
+func (s *StateTracker) TrackEnable(changeID string, snap *client.Snap) {
+	if isInstalled(snap) {
+		return
+	}
+
+	if tracked, _ := s.IsTrackedForRunningOperation(snap); tracked {
+		return
+	}
+
+	s.trackOperation(changeID, snap.Name, StatusInstalling)
+}
+
+// TrackDisable tracks the disabling of the given snap
+func (s *StateTracker) TrackDisable(changeID string, snap *client.Snap) {
+	if !isInstalled(snap) {
+		return
+	}
+
+	if tracked, _ := s.IsTrackedForRunningOperation(snap); tracked {
+		return
+	}
+
+	s.trackOperation(changeID, snap.Name, StatusUninstalling)
 }
 
 func (s *StateTracker) trackOperation(changeID, name, operation string) {
@@ -150,15 +199,6 @@ func (s *StateTracker) trackOperation(changeID, name, operation string) {
 		delete(s.states, name)
 		s.Unlock()
 	}()
-}
-
-// TrackUninstall tracks the removal of the given snap
-func (s *StateTracker) TrackUninstall(changeID string, snap *client.Snap) {
-	if !isInstalled(snap) {
-		return
-	}
-
-	s.trackOperation(changeID, snap.Name, StatusUninstalling)
 }
 
 func isInstalled(s *client.Snap) bool {
@@ -180,9 +220,15 @@ func translateStatus(s *client.Snap) string {
 }
 
 // has the tracked process denoted by status completed?
-func hasCompleted(status string, snap *client.Snap) bool {
-	if status == StatusInstalling {
+func hasOperationCompleted(s string, snap *client.Snap) bool {
+	if s == StatusInstalling {
 		return isInstalled(snap)
+	}
+	if s == StatusEnabling {
+		return s.Status == client.StatusActive
+	}
+	if s == StatusInstalling {
+		return s.Status == client.StatusInstalled
 	}
 
 	return !isInstalled(snap)

--- a/www/src/js/behaviors/enabler.js
+++ b/www/src/js/behaviors/enabler.js
@@ -1,0 +1,40 @@
+// install behavior
+var _ = require('lodash');
+var Backbone = require('backbone');
+var Marionette = require('backbone.marionette');
+var CONF = require('../config.js');
+var Snap = require('../common/snaps.js');
+
+module.exports = Marionette.Behavior.extend({
+  events: {
+    'click @ui.enableButton': 'onEnableClick'
+  },
+
+  modelEvents: {
+    'change:status': 'onStatusChange'
+  },
+
+  ui: {
+    enableButton: '.b-enable__button'
+  },
+
+  onStatusChange: function(model) {
+    var oldState = model.previous('status');
+    var state = model.get('status');
+    var msg = model.get('installActionString');
+    var installer = this.ui.installer;
+    var installerButton = this.ui.enableButton;
+
+    if (_.contains(CONF.INSTALL_STATE, state)) {
+      enableButton.text(msg);
+    } else {
+      // in the rare case that a status isn't one we're expecting,
+      // remove the install button
+//       installer.remove();
+    }
+  },
+
+  onInstallClick: function(event) {
+    return Snap.handleEnableEvent(event, this.view.model);
+  },
+});

--- a/www/src/js/common/snaplists.js
+++ b/www/src/js/common/snaplists.js
@@ -21,6 +21,7 @@ module.exports = {
         })
         collection.forEach(function(s) {
           if (installedById[s.id]) {
+            // TODO make sure that active & installed state is preserved
             s.set('status', CONF.INSTALL_STATE.INSTALLED)
           }
         });

--- a/www/src/js/config.js
+++ b/www/src/js/config.js
@@ -26,6 +26,8 @@ module.exports = {
     INSTALLING: 'installing',
     REMOVED: 'uninstalled',
     REMOVING: 'uninstalling',
+    ENABLING: 'enabling',
+    DISABLING: 'disabling',
     ACTIVE: 'active',
     PRICED: 'priced'
   },

--- a/www/src/js/models/snap.js
+++ b/www/src/js/models/snap.js
@@ -34,7 +34,9 @@ module.exports = Backbone.Model.extend({
 
       if (
         status === CONF.INSTALL_STATE.INSTALLING ||
-        status === CONF.INSTALL_STATE.REMOVING
+        status === CONF.INSTALL_STATE.REMOVING ||
+        status === CONF.INSTALL_STATE.DISABLING ||
+        status === CONF.INSTALL_STATE.ENABLING
       ) {
         _.delay(function(model) {
           model.fetch();
@@ -90,8 +92,9 @@ module.exports = Backbone.Model.extend({
     var status = model.get('status');
     if (
         status !== CONF.INSTALL_STATE.INSTALLING &&
-        status !== CONF.INSTALL_STATE.REMOVING
-    ) {
+        status !== CONF.INSTALL_STATE.REMOVING &&
+        status !== CONF.INSTALL_STATE.DISABLING &&
+        status !== CONF.INSTALL_STATE.ENABLING) {
       model.set('download_progress', 0);
       model.set('task_summary', '');
     }
@@ -117,7 +120,9 @@ module.exports = Backbone.Model.extend({
       installHTMLClass = 'b-installer_do_remove';
     }
 
-    if (status === CONF.INSTALL_STATE.INSTALLING) {
+    if (status === CONF.INSTALL_STATE.INSTALLING ||
+        status === CONF.INSTALL_STATE.DISABLIGN ||
+        status === CONF.INSTALL_STATE.ENABLING) {
       installHTMLClass = 'b-installer_do_install b-installer_thinking';
     }
 
@@ -138,6 +143,8 @@ module.exports = Backbone.Model.extend({
         break;
       case CONF.INSTALL_STATE.ACTIVE:
       case CONF.INSTALL_STATE.INSTALLED:
+      case CONF.INSTALL_STATE.ENABLING:
+      case CONF.INSTALL_STATE.DISABLING:
         action = 'Remove';
         break;
       case CONF.INSTALL_STATE.INSTALLING:
@@ -165,6 +172,8 @@ module.exports = Backbone.Model.extend({
 
     switch (status) {
       case CONF.INSTALL_STATE.ACTIVE:
+      case CONF.INSTALL_STATE.ENABLING:
+      case CONF.INSTALL_STATE.DISABLING:
       case CONF.INSTALL_STATE.INSTALLED:
       case CONF.INSTALL_STATE.INSTALLING:
         installButtonClass = 'button--secondary';
@@ -199,13 +208,22 @@ module.exports = Backbone.Model.extend({
     if (
       status === CONF.INSTALL_STATE.INSTALLED ||
       status === CONF.INSTALL_STATE.ACTIVE ||
-      status === CONF.INSTALL_STATE.REMOVING
+      status === CONF.INSTALL_STATE.REMOVING ||
+      status === CONF.INSTALL_STATE.ENABLING ||
+      status === CONF.INSTALL_STATE.DISABLING
     ) {
       response.isInstalled = true;
     }
 
     if (response.hasOwnProperty('icon') && !response.icon.length) {
       response.icon = this.defaults.icon;
+    }
+
+    response.isEnabled = false;
+    if (status === CONF.INSTALL_STATE.INSTALLED) {
+      response.isEnabled = false;
+    } else if (status === CONF.INSTALL_STATE.ACTIVE) {
+      response.isEnabled = true;
     }
 
     if (status === CONF.INSTALL_STATE.PRICED) {

--- a/www/src/js/templates/_enabler.hbs
+++ b/www/src/js/templates/_enabler.hbs
@@ -1,0 +1,17 @@
+{{#if isInstalled}}
+
+{{#if isEnabled}}
+
+  <div class="b-installer">
+    <button class="b-enabler__button p-button--neutral">Disable</button>
+  </div>
+
+{{else}}
+
+  <div class="b-installer">
+    <button class="b-enabler__button p-button--neutral">Enable</button>
+  </div>
+
+{{/if}}
+
+{{/if}}

--- a/www/src/js/templates/snap-layout.hbs
+++ b/www/src/js/templates/snap-layout.hbs
@@ -13,6 +13,11 @@
 
     <div class="row">
       <div class="col-7"></div>
+
+      <div class="col-5 u-float--right">
+        {{> enabler}}
+      </div>
+
       <div class="col-5 u-float--right">
         {{> installer}}
 

--- a/www/src/js/views/snap-layout.js
+++ b/www/src/js/views/snap-layout.js
@@ -6,10 +6,14 @@ Backbone.$ = $;
 var Marionette = require('backbone.marionette');
 var Handlebars = require('hbsfy/runtime');
 var InstallBehavior = require('../behaviors/install.js');
+var EnableBehavior = require('../behaviors/enabler.js');
 var template = require('../templates/snap-layout.hbs');
 var CONF = require('../config.js');
 
+// Handles the install/remove button
 Handlebars.registerPartial('installer', require('../templates/_installer.hbs'));
+// Handles the enable/disable button
+Handlebars.registerPartial('enabler', require('../templates/_enabler.hbs'));
 
 var SnapInterfaceListItemView = Marionette.ItemView.extend({
   tagName: 'li',
@@ -54,6 +58,9 @@ module.exports = Marionette.LayoutView.extend({
   behaviors: {
     InstallBehavior: {
       behaviorClass: InstallBehavior
+    },
+    EnableBehavior: {
+      behaviorClass: EnableBehavior
     }
   },
 


### PR DESCRIPTION
ui & backend, snap enable & disable
extend the state manager as a long running operation manager
start refactoring js to abstract long running operations instead of only install/remove
