### PR TITLE
Travis debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,8 @@ after_success:
   - openssl aes-256-cbc -K $encrypted_e72199912f3d_key -iv $encrypted_e72199912f3d_iv
     -in .snapcraft/travis_snapcraft.cfg -out "${HOME}/.config/snapcraft/snapcraft.cfg" -d
 
-after_failure: "cat /go/src/github.com/snapcore/snapweb/npm-debug.log"
+after_failure:
+  - cat npm-debug.log
 
 deploy:
   'on':

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ after_success:
   - openssl aes-256-cbc -K $encrypted_e72199912f3d_key -iv $encrypted_e72199912f3d_iv
     -in .snapcraft/travis_snapcraft.cfg -out "${HOME}/.config/snapcraft/snapcraft.cfg" -d
 
+after_failure: "cat /go/src/github.com/snapcore/snapweb/npm-debug.log"
+
 deploy:
   'on':
     branch: master

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "karma-jasmine-ajax": "^0.1.12",
     "karma-phantomjs-launcher": "~0.1.4",
     "karma-phantomjs-shim": "^1.4.0",
+    "phantomjs-prebuilt": "^2.1.5",
     "gulp": "~3.9.1",
     "gulp-concat": "~2.5.2",
     "gulp-csso": "~1.0.0",


### PR DESCRIPTION
This prints the npm-debug-log on errors.
It also changes package.json to using the phantomjs-prebuilt package.

In an attempt to clear the issues plaguing the Travis builds...