### PR TITLE
Reenable disabled tests

### DIFF
--- a/snappy/app/converge_test.go
+++ b/snappy/app/converge_test.go
@@ -20,6 +20,7 @@ package snappy
 import (
 	"errors"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/snapcore/snapd/client"
@@ -29,6 +30,8 @@ import (
 	"github.com/snapcore/snapweb/snappy/common"
 	"github.com/snapcore/snapweb/statetracker"
 )
+
+func Test(t *testing.T) { TestingT(t) }
 
 type GetSnapSuite struct {
 	h Handler

--- a/statetracker/statetracker.go
+++ b/statetracker/statetracker.go
@@ -97,7 +97,7 @@ func (s *StateTracker) State(c snapdclient.SnapdClient, snap *client.Snap) *Snap
 	if changing, changeID := s.IsTrackedForRunningOperation(snap); changing && c != nil {
 		change, err := c.Change(changeID)
 
-		if err == nil {
+		if change != nil && err == nil {
 			for _, task := range change.Tasks {
 				if uint64(task.Progress.Done) > 1 {
 					cstate.LocalSize = uint64(task.Progress.Done)


### PR DESCRIPTION
Quite a few tests for the go part have been hidden by recent project structure refactoring, this is to re-enable them and improve the overall coverage %