### PR TITLE
Hide interface list until we have fixed it at the snapd level; handle…

### DIFF
--- a/www/src/js/common/snaplists.js
+++ b/www/src/js/common/snaplists.js
@@ -23,10 +23,12 @@ module.exports = {
           if (installedById[s.id]) {
             // TODO make sure that active & installed state is preserved
             s.set('status', CONF.INSTALL_STATE.INSTALLED)
+            s.set('icon', installedById[s.id].get('icon'))
           }
         });
       },
       error: function(snaplist) {
+	console.log('error')
       }
     });
     return collection

--- a/www/src/js/controllers/home.js
+++ b/www/src/js/controllers/home.js
@@ -29,6 +29,9 @@ module.exports = {
         });
 
         chan.command('set:content', {backboneView: installedSnapsView});
+      },
+      error: function() {
+	console.log('error')
       }
     });
   },

--- a/www/src/js/controllers/store.js
+++ b/www/src/js/controllers/store.js
@@ -60,6 +60,8 @@ var fetchSnapList = function(title, options) {
 
   storeSnaplist.fetch(options).always(function(response) {
     storeModel.set('loading', false);
+  }).done(function() {
+      storeSnaplist = SnaplistTools.updateInstalledStates(storeSnaplist)
   });
 }
 

--- a/www/src/js/templates/snap-layout.hbs
+++ b/www/src/js/templates/snap-layout.hbs
@@ -68,6 +68,7 @@
   <div class="col-5" style="border: 1px dotted #cdcdcd; padding: 1em 1em; height: 15em; overflow-x: hidden; overflow-y: scroll;">
     <h3 class="">Interfaces</h3>
     <div id="interface-list">
+    Interface list not available
     </div>
   </div>
 

--- a/www/src/js/templates/snap-layout.hbs
+++ b/www/src/js/templates/snap-layout.hbs
@@ -65,10 +65,10 @@
 
   </div>
 
-  <div class="col-5" style="border: 1px dotted #cdcdcd; padding: 1em 1em; height: 15em; overflow-x: hidden; overflow-y: scroll;">
+  <div class="col-5" style="border: 1px dotted #cdcdcd; padding: 1em 1em; height: 15em; overflow-x: hidden; overflow-y: hidden;">
     <h3 class="">Interfaces</h3>
     <div id="interface-list">
-    Interface list not available
+      <li>N/A</li>
     </div>
   </div>
 

--- a/www/src/js/views/snap-layout.js
+++ b/www/src/js/views/snap-layout.js
@@ -74,13 +74,17 @@ module.exports = Marionette.LayoutView.extend({
   },
 
   onBeforeShow: function() {
-    this.showChildView(
+    // disabled for now until https://bugs.launchpad.net/snapweb/+bug/1668390
+    // is fixed
+    /*
+this.showChildView(
         'interfacesRegion',
         new SnapInterfaceCollectionView({
           model: this.model,
           collection: this.collection
         })
     );
+*/
   },
 
   onShow: function() {


### PR DESCRIPTION
… model merges for icons during install
