### PR TITLE
added extra information to run_checks when gofmt fails

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -78,7 +78,10 @@ if [ ! -z "$STATIC_GO" ]; then
 
     if [ -n "$fmt" ]; then
         echo "Formatting wrong in following files"
-        echo $fmt
+        echo "$fmt"
+        echo "Getting formating diff..."
+        fmt_diff=$(gofmt -d .)
+        echo "$fmt_diff"
         exit 1
     fi
 


### PR DESCRIPTION
I saw the Travis job: https://travis-ci.org/snapcore/snapweb/jobs/212944787 failed.
But I ran run_checks before committing and in fact now again and I don't get any complain about formatting.

What this branch adds is some extra information when gomft fails. It prints the diff of formatting as a reference.

It also prints the files that gofmt return with newlines.