### PR TITLE
Change regex to ensure we always grab a line with snapweb.

### DIFF
--- a/spread/main/installation/task.yaml
+++ b/spread/main/installation/task.yaml
@@ -5,6 +5,6 @@ execute: |
     systemctl status snap.snapweb.snapweb.service
 
     # Ensure all necessary plugs/slots are connected
-    snap interfaces | grep -Pzq ":snapd-control +snapweb"
-    snap interfaces | grep -Pzq ":network +snapweb"
-    snap interfaces | grep -Pzq ":network-bind +snapweb"
+    snap interfaces | grep -Pzq ":snapd-control.+snapweb"
+    snap interfaces | grep -Pzq ":network.+snapweb"
+    snap interfaces | grep -Pzq ":network-bind.+snapweb"


### PR DESCRIPTION
Other connected snaps (core, for e.g.) will interfere with the current regex.