### PR TITLE
added additional needed deps for armhf

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -42,5 +42,7 @@ parts:
     source: .
     build-packages:
       - git
-      - python2.7-dev
+      - python
+      - g++
+      - build-essential
 


### PR DESCRIPTION
some build packages are needed for armhf to build and were not included initially in snapweb-ui part.
python package must also replace python2.7 one.