### PR TITLE
Removed class C networks restriction

### DIFF
--- a/pkg/meta/snap.yaml
+++ b/pkg/meta/snap.yaml
@@ -1,5 +1,5 @@
 name: snapweb
-version: "0.26.9"
+version: "0.26.11"
 summary: Beautiful and functional interface for snap management
 description: |
   This service allows you to manage your Ubuntu Core device from a web interface or REST API.

--- a/pkg/meta/snap.yaml
+++ b/pkg/meta/snap.yaml
@@ -1,5 +1,5 @@
 name: snapweb
-version: "0.26.11"
+version: "0.26-11"
 summary: Beautiful and functional interface for snap management
 description: |
   This service allows you to manage your Ubuntu Core device from a web interface or REST API.

--- a/snappy/app/netfilter.go
+++ b/snappy/app/netfilter.go
@@ -108,10 +108,7 @@ func (f *NetFilter) AddLocalNetworkForInterface(ifname string) {
 				f.AllowNetwork(ipnet.String())
 			} else if ipnet.IP.To4() != nil {
 				// only consider IPv4 networks
-				// only consider class-C networks, ie with 256 hosts max.
-				if ones, _ := ipnet.Mask.Size(); ones >= 24 {
-					f.AllowNetwork(ipnet.String())
-				}
+				f.AllowNetwork(ipnet.String())
 			} // TODO: add proper IPV6 support
 		}
 	}

--- a/snappy/app/netfilter.go
+++ b/snappy/app/netfilter.go
@@ -104,12 +104,11 @@ func (f *NetFilter) AddLocalNetworkForInterface(ifname string) {
 
 	for _, a := range addrs {
 		if ipnet, ok := a.(*net.IPNet); ok {
-			if ipnet.IP.IsLoopback() {
+			// only consider lo or IPv4 networks
+			if ipnet.IP.IsLoopback() || ipnet.IP.To4() != nil {
 				f.AllowNetwork(ipnet.String())
-			} else if ipnet.IP.To4() != nil {
-				// only consider IPv4 networks
-				f.AllowNetwork(ipnet.String())
-			} // TODO: add proper IPV6 support
+			}
+			// TODO: add proper IPV6 support
 		}
 	}
 


### PR DESCRIPTION
This restriction was originally included as a kind of security for not allowing to use snapweb in big networks.
This makes no sense now since there is an authentication by token and fixes the problem of having snapweb available in class B or class A networks